### PR TITLE
Use error reporting of Respec

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import mermaid from 'mermaid';
 
-function addMermaidStyles() {
+function addMermaidStyles(document) {
   const mermaidStyles = document.createElement('style');
 
   mermaidStyles.innerHTML += `
@@ -10,7 +10,7 @@ function addMermaidStyles() {
   document.getElementsByTagName('head')[0].appendChild(mermaidStyles);
 }
 
-function addMermaidScripts() {
+function addMermaidScripts(document) {
   const mermaidScripts = document.createElement('script');
   mermaidScripts.type = 'text/javascript';
   mermaidScripts.text += `
@@ -21,12 +21,12 @@ function addMermaidScripts() {
   mermaid.mermaidAPI.initialize({startOnLoad:false});
 }
 
-async function createFigures() {
+async function createFigures(config, document, utils) {
   // add scripts for figures
-  addMermaidScripts();
+  addMermaidScripts(document);
 
   // add styles for figures
-  addMermaidStyles();
+  addMermaidStyles(document);
 
   // process every mermaid figure in the document
   const mermaidFigures = document.querySelectorAll(".mermaid");
@@ -45,8 +45,10 @@ async function createFigures() {
       figure.remove();
       figureNum++;
     } catch(e) {
-      console.error('respec-mermaid error: Failed to generate figure.',
-        e, mermaidSource);
+      utils.showError('Failed to generate figure', {
+        elements: [figure.firstChild],
+        cause: e,
+      });
       continue;
     }
   }


### PR DESCRIPTION
Respec does not print all `console.errors`. It only prints the first argument. Instead, it provides a warning/error mechanism [1] to show errors.

This was suggested to use as an alternative fix in Respec itself [2] and provides more information to the user in the console when run with `--verbose`.

[1]: https://github.com/speced/respec/wiki/extension-utils-object
[2]: https://github.com/speced/respec/pull/4926#issuecomment-2775312536