### PR TITLE
Added workaround for BR tag bug (https://github.com/mermaid-js/mermaid/issues/1766)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ renders the SVG diagram shown below):
 To use this extension, include the following line in your ReSpec file:
 
 ```html
-<script class="remove" src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-mermaid@1.0.0/dist/main.js"></script>
+<script class="remove" src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-mermaid@1.0.1/dist/main.js"></script>
 ```
 
 and set the following configuration option in your ReSpec configuration:

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ async function createFigures() {
       await mermaid.mermaidAPI.render(
         'diagram-' + figureNum, mermaidSource, (svgCode, bindFunctions) => {
           const template = document.createElement('template');
-          template.innerHTML = svgCode.trim();
+          const cleanedSvg = svgCode.trim().replace(/height="[0-9]*"/, '');
+          template.innerHTML = cleanedSvg;
           figure.parentElement.prepend(template.content.firstChild);
           figure.remove();
       });
@@ -49,9 +50,6 @@ async function createFigures() {
         e, mermaidSource);
       continue;
     }
-
-    // append the examples
-    //example.after(preJwt);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/respec-mermaid#readme",
   "dependencies": {
-    "mermaid": "^9.0.0"
+    "mermaid": "^10.6.1"
   },
   "devDependencies": {
     "http-server": "^13.0.0",


### PR DESCRIPTION
Replacing HTML \<br\> with XHTML \<br/\> is essentially impossible; there are multiple points in Mermaid and ReSpec Mermaid that roll back the replacement. For example, line 43 of index.js:

```javascript
template.innerHTML = cleanedSvg;
```

This assignment hands control over to the DOM, which promptly reverts to \<br\>, even though the \<foreignObject\> content is XHTML.

To get around this, \<br\> tags are replaced with \</p\>\<p\> (closing and opening paragraph markers).

The end result is an XML-conformant SVG.