### PR TITLE
Export mermaid on window

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ Check this repository's
 [tags](https://github.com/digitalbazaar/respec-mermaid/tags) for all known
 releases.
 
+## Mermaid extensions
+
+Extensions to Mermaid can be added by using `window.respecMermaid.mermaid` to access mermaid:
+
+```js
+// index.js 
+
+async function registerDiagrams() {
+    await window.respecMermaid.mermaid.registerExternalDiagrams([myDiagrams]);
+}
+
+window.myRespecMermaidExtension = {
+    registerDiagrams
+};
+```
+
+Adding the appropriate script tags
+
+```html
+<script class="remove" src="https://url.to.my.extension/index.js"></script>
+```
+
+And being initialized in the ReSpec configuration before the figures are created: 
+
+```js
+preProcess: [window.myRespecMermaidExtension.registerDiagrams, window.respecMermaid.createFigures]
+```
+
+
 # ReSpec Markup
 
 To use this extension, you must add the `mermaid` class to your content block.

--- a/index.js
+++ b/index.js
@@ -56,5 +56,7 @@ async function createFigures(config, document, utils) {
 
 // setup exports on window
 window.respecMermaid = {
-  createFigures
+  createFigures,
+  // Export mermaid as well so that plugins can register custom diagrams if they want to.
+  mermaid
 }


### PR DESCRIPTION
Export mermaid library so that plugins can call `mermaid.registerExternalDiagrams([plugin]);`

Address https://github.com/w3c/respec-mermaid/issues/12